### PR TITLE
Create responsive canvas piano keyboard demo

### DIFF
--- a/public/pixel-perfect-piano.html
+++ b/public/pixel-perfect-piano.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pixel Perfect Piano Keyboard</title>
+  <style>
+    *, *::before, *::after {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #101010;
+      color: #e8e8e8;
+      font-family: "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      padding: 2rem 1.5rem;
+    }
+
+    main {
+      width: 100%;
+      max-width: 960px;
+    }
+
+    h1 {
+      font-size: clamp(1.5rem, 2vw + 1rem, 2.25rem);
+      margin: 0 0 1rem;
+      text-align: center;
+      letter-spacing: 0.04em;
+    }
+
+    p {
+      margin: 0 0 1.5rem;
+      text-align: center;
+      color: #bbb;
+      font-size: 0.95rem;
+    }
+
+    canvas {
+      display: block;
+      width: 100%;
+      height: auto;
+      margin: 0 auto;
+      background: #000;
+      border-radius: 6px;
+      box-shadow: 0 14px 40px rgba(0, 0, 0, 0.45);
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Canvas Piano Keyboard</h1>
+    <p>リサイズしても黒鍵に白線が乗らない、ピクセルパーフェクトなピアノ鍵盤。</p>
+    <canvas id="kb" role="img" aria-label="ピアノ鍵盤"></canvas>
+  </main>
+  <script>
+    (() => {
+      const canvas = document.getElementById('kb');
+      const ctx = canvas.getContext('2d');
+      const BLACK_KEY_INDICES = [0, 1, 3, 4, 5];
+      const BLACK_WIDTH_RATIO = 0.6;
+      const BLACK_HEIGHT_RATIO = 0.62;
+
+      const defaults = {
+        octaves: 3,
+        whiteKeyWidth: 60,
+        whiteKeyHeight: 240,
+        gapPx: 1
+      };
+
+      let activeConfig = { ...defaults };
+
+      function getCssWidth() {
+        const rect = canvas.getBoundingClientRect();
+        if (rect.width > 0) return rect.width;
+        if (canvas.parentElement) return canvas.parentElement.clientWidth;
+        return window.innerWidth || defaults.octaves * defaults.whiteKeyWidth * 7;
+      }
+
+      function drawKeyboard() {
+        const dpr = window.devicePixelRatio || 1;
+        const totalWhites = activeConfig.octaves * 7;
+
+        canvas.style.width = '100%';
+        const cssWidth = Math.max(1, getCssWidth());
+        const deviceWidth = Math.max(1, Math.round(cssWidth * dpr));
+
+        const gapDevice = Math.max(1, Math.round(activeConfig.gapPx * dpr));
+        const slotSize = (deviceWidth - gapDevice) / totalWhites;
+        const whiteWidthFloat = slotSize - gapDevice;
+
+        if (whiteWidthFloat <= 0) {
+          canvas.width = Math.round(deviceWidth);
+          canvas.height = 1;
+          canvas.style.height = `${1 / dpr}px`;
+          ctx.clearRect(0, 0, canvas.width, canvas.height);
+          return;
+        }
+
+        const baseWhiteWidthDevice = Math.max(activeConfig.whiteKeyWidth, 1) * dpr;
+        const baseWhiteHeightDevice = Math.max(activeConfig.whiteKeyHeight, 1) * dpr;
+        const widthScale = whiteWidthFloat / baseWhiteWidthDevice;
+        const whiteKeyHeightDevice = Math.max(1, Math.round(baseWhiteHeightDevice * widthScale));
+        const canvasHeight = whiteKeyHeightDevice;
+
+        canvas.width = Math.round(deviceWidth);
+        canvas.height = canvasHeight;
+        canvas.style.height = `${canvasHeight / dpr}px`;
+
+        ctx.save();
+        ctx.fillStyle = '#000';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+        const whiteKeyMetrics = [];
+        const stepFloat = whiteWidthFloat + gapDevice;
+
+        ctx.fillStyle = '#fff';
+        for (let i = 0; i < totalWhites; i++) {
+          const keyFloatLeft = gapDevice + i * stepFloat;
+          const keyFloatRight = keyFloatLeft + whiteWidthFloat;
+          const nextSlotFloat = gapDevice + (i + 1) * stepFloat;
+
+          const x = Math.round(keyFloatLeft);
+          const rightEdgeInt = Math.round(nextSlotFloat) - gapDevice;
+          let width = rightEdgeInt - x;
+          if (i === totalWhites - 1) {
+            width = Math.max(width, canvas.width - gapDevice - x);
+          }
+
+          if (width > 0) {
+            ctx.fillRect(x, 0, width, whiteKeyHeightDevice);
+          }
+
+          whiteKeyMetrics.push({
+            leftFloat: keyFloatLeft,
+            rightFloat: keyFloatRight
+          });
+        }
+
+        ctx.fillStyle = '#000';
+        const blackWidthFloat = whiteWidthFloat * BLACK_WIDTH_RATIO;
+        const blackHeight = Math.max(1, Math.round(whiteKeyHeightDevice * BLACK_HEIGHT_RATIO));
+
+        for (let octave = 0; octave < activeConfig.octaves; octave++) {
+          for (const offset of BLACK_KEY_INDICES) {
+            const whiteIndex = octave * 7 + offset;
+            const anchor = whiteKeyMetrics[whiteIndex];
+            if (!anchor) continue;
+
+            const bxFloat = anchor.rightFloat - blackWidthFloat / 2;
+            const x = Math.round(bxFloat);
+            const right = Math.round(bxFloat + blackWidthFloat);
+            const width = Math.max(0, right - x);
+            if (width === 0) continue;
+
+            ctx.fillRect(x, 0, width, blackHeight);
+          }
+        }
+
+        ctx.restore();
+      }
+
+      function renderKeyboard(options = {}) {
+        activeConfig = { ...activeConfig, ...options };
+        drawKeyboard();
+      }
+
+      window.renderKeyboard = renderKeyboard;
+
+      let resizeHandle = null;
+      const handleResize = () => {
+        if (resizeHandle !== null) {
+          cancelAnimationFrame(resizeHandle);
+        }
+        resizeHandle = requestAnimationFrame(() => {
+          resizeHandle = null;
+          drawKeyboard();
+        });
+      };
+
+      window.addEventListener('resize', handleResize, { passive: true });
+      renderKeyboard();
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone HTML page that renders a layered piano keyboard on a canvas without strokes
- ensure the drawing logic accounts for devicePixelRatio to keep 1px gaps and redraws on resize

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7f46a6150832da07ec8186ac460a1